### PR TITLE
chore: update testing_mock for better sbfl analysis scores

### DIFF
--- a/src/testing_mock/data.json
+++ b/src/testing_mock/data.json
@@ -30,7 +30,7 @@
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10CalculatorC2Eii",
             "line": 6,
-            "score": 0.4082482905
+            "score": 0.5270462767
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
@@ -60,13 +60,13 @@
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator8multiplyEv",
             "line": 16,
-            "score": 0.0
+            "score": 0.894427191
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator8multiplyEv",
             "line": 17,
-            "score": 0.0
+            "score": 0.894427191
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
@@ -132,31 +132,31 @@
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator14area_rectangleEv",
             "line": 38,
-            "score": 1.0
-        },
-        {
-            "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
-            "function": "_ZN10Calculator14area_rectangleEv",
-            "line": 39,
-            "score": 1.0
+            "score": 0.5163977795
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator14area_rectangleEv",
             "line": 40,
-            "score": 1.0
+            "score": 0.5163977795
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator14area_rectangleEv",
             "line": 41,
-            "score": 1.0
+            "score": 0.4472135955
         },
         {
             "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
             "function": "_ZN10Calculator14area_rectangleEv",
-            "line": 42,
-            "score": 1.0
+            "line": 43,
+            "score": 0.316227766
+        },
+        {
+            "file": "/workspace/src/testing_mock/build/CMakeFiles/calculator_lib.dir/src/calculator.gcno///workspace/src/testing_mock/src/calculator.cpp",
+            "function": "_ZN10Calculator14area_rectangleEv",
+            "line": 45,
+            "score": 0.5163977795
         }
     ]
 }

--- a/src/testing_mock/src/calculator.cpp
+++ b/src/testing_mock/src/calculator.cpp
@@ -14,7 +14,7 @@ int Calculator::subtract() {
 }
 
 int Calculator::multiply() {
-    return first_operand * second_operand;
+    return first_operand + second_operand;
 }
 
 double Calculator::divide() {
@@ -36,8 +36,11 @@ double Calculator::sqrt_second() {
 
 
 double Calculator::area_rectangle() {
-     int width = first_operand;
-    int height = second_operand;
-    int result = width + height;
+    int result;
+    if (first_operand > 0 && second_operand > 0) {
+        result = multiply();
+    } else {
+        result = 0;
+    }
     return result;
 }


### PR DESCRIPTION


What is in this change?

Modification to testing mock

This change includes modifying our testing mock area calculator for more complexity. This will provide better localized errors for our fix ingredients.

What is the impact of this change?

Provides better context to retrieve fix ingredients.

How did you verify this change?

Github actions test passed

Does it break any previous versions?

No

When should this be merged?

ASAP
