### PR TITLE
Refactor: Modify prioritizer component to return PatchCandidate vector

### DIFF
--- a/src/core/contracts.h
+++ b/src/core/contracts.h
@@ -71,7 +71,7 @@ public:
    * @param test_results test execution results for feature extraction
    * @return vector of prioritized patches sorted by priority score
    */
-  virtual std::vector<PrioritizedPatch>
+  virtual std::vector<PatchCandidate>
   prioritizePatches(const std::vector<PatchCandidate> &patch_candidates,
                     const std::string &mutation_freq_json) = 0;
 };
@@ -91,7 +91,7 @@ public:
    * @return vector of validation results
    */
   virtual std::vector<ValidationResult>
-  validatePatches(const std::vector<PrioritizedPatch> &prioritized_patches,
+  validatePatches(const std::vector<PatchCandidate> &prioritized_patches,
                   const RepositoryMetadata &repo_metadata, int top_k = 10) = 0;
 };
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -143,11 +143,12 @@ struct PatchCandidate {
   std::vector<std::string> affected_tests;
   double suspiciousness_score;
   double similarity_score;
+  double priority_score;
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(PatchCandidate, patch_id, target_node_id, file_path,
                                  start_line, end_line, original_code,
                                  modified_code, diff, mutation_type,
-                                 affected_tests, similarity_score, suspiciousness_score)
+                                 affected_tests, similarity_score, suspiciousness_score, priority_score)
 };
 
 
@@ -239,7 +240,7 @@ struct SystemState {
   std::vector<SuspiciousLocation> suspicious_locations;
   std::vector<ASTNode> ast_nodes;
   std::vector<PatchCandidate> patch_candidates;
-  std::vector<PrioritizedPatch> prioritized_patches;
+  std::vector<PatchCandidate> prioritized_patches;
   std::vector<ValidationResult> validation_results;
   bool has_pr_result;
   PRResult pr_result;

--- a/src/mutator/mutator.cpp
+++ b/src/mutator/mutator.cpp
@@ -115,7 +115,8 @@ std::vector<PatchCandidate> Mutator::generatePatches(
         MutationType{"Replacement", "identifier", ""},
         {"test_add_positive", "test_add_negative"},
         0.85,
-        0.92
+        0.92,
+        0
     };
 
     PatchCandidate mock_patch2{
@@ -130,7 +131,8 @@ std::vector<PatchCandidate> Mutator::generatePatches(
         MutationType{"Deletion", "identifier", "binary_expression"},
         {"test_multiply_positive"},
         0.78,
-        0.88
+        0.88,
+        0
     };
 
    

--- a/src/prioritizer/prioritizer.h
+++ b/src/prioritizer/prioritizer.h
@@ -27,7 +27,7 @@ public:
    * @param mutation_freq_json mutation frequencies
    * @return vector of prioritized patches sorted by priority score
    */
-  std::vector<PrioritizedPatch>
+  std::vector<PatchCandidate>
   prioritizePatches(const std::vector<PatchCandidate> &patch_candidates,
                     const std::string& mutation_freq_json);
 

--- a/src/validator/validator.cpp
+++ b/src/validator/validator.cpp
@@ -4,7 +4,7 @@
 namespace apr_system {
 
 std::vector<ValidationResult> Validator::validatePatches(
-    const std::vector<PrioritizedPatch>& prioritized_patches,
+    const std::vector<PatchCandidate>& prioritized_patches,
     const RepositoryMetadata& repo_metadata,
     int top_k
 ) {
@@ -39,16 +39,16 @@ std::vector<ValidationResult> Validator::validatePatches(
     for (int i = 0; i < patches_to_validate; ++i) {
         const auto& patch = prioritized_patches[i];
 
-        LOG_COMPONENT_DEBUG("validator", "validating patch {}/{}: {}", i + 1, patches_to_validate, patch.patch_id_ref);
+        LOG_COMPONENT_DEBUG("validator", "validating patch {}/{}: {}", i + 1, patches_to_validate, patch.patch_id);
 
         ValidationResult result{
-            .patch_id = patch.patch_id_ref,
+            .patch_id = patch.patch_id,
             .compilation_success = i < 2, // first 2 patches compile successfully
             .tests_passed = i == 0,       // only first patch passes tests
             .build_time_ms = 1000 + (i * 200),  // mock build times
             .test_time_ms = 500 + (i * 100),    // mock test times
-            .build_output = "[STUB] mock build output for patch " + patch.patch_id_ref,
-            .test_output = "[STUB] mock test output for patch " + patch.patch_id_ref,
+            .build_output = "[STUB] mock build output for patch " + patch.patch_id,
+            .test_output = "[STUB] mock test output for patch " + patch.patch_id,
             .error_message = i >= 2 ? "mock compilation error" : "",
             .tests_passed_count = i == 0 ? 5 : (i == 1 ? 3 : 0),
             .tests_total_count = 5

--- a/src/validator/validator.h
+++ b/src/validator/validator.h
@@ -23,7 +23,7 @@ public:
    * @return vector of validation results
    */
   std::vector<ValidationResult>
-  validatePatches(const std::vector<PrioritizedPatch> &prioritized_patches,
+  validatePatches(const std::vector<PatchCandidate> &prioritized_patches,
                   const RepositoryMetadata &repo_metadata,
                   int top_k = 10) override;
 


### PR DESCRIPTION
### Whats in this change?
Modified the `prioritizer` component to return `vector<PatchCandidate>` instead of `vector<PrioritizedPatch>`. This allows us to easily access all the information of a patch candidate inside the `validator` component, instead of needing to reference this through the `patch_id_ref` attribute of the `PrioritizedPatch` type.